### PR TITLE
Make the core `State` and methods independent from `khatru`

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 = relay29 image:https://pkg.go.dev/badge/github.com/fiatjaf/relay29.svg[link=https://pkg.go.dev/github.com/fiatjaf/relay29]
 
-a library for creating NIP-29 relays, based on https://github.com/fiatjaf/khatru[khatru].
+A library for creating NIP-29 relays, works with https://github.com/fiatjaf/khatru[khatru] using the https://pkg.go.dev/github.com/fiatjaf/relay29/khatru29[khatru29] wrapper.
 
 CAUTION: This is probably broken so please don't trust it for anything serious and be prepared to delete your database.
 
@@ -16,25 +16,28 @@ import (
 	"github.com/fiatjaf/eventstore/slicestore"
 	"github.com/fiatjaf/khatru/policies"
 	"github.com/fiatjaf/relay29"
+	"github.com/fiatjaf/relay29/khatru29"
 	"github.com/nbd-wtf/go-nostr"
-	"golang.org/x/exp/slices"
 )
 
 func main() {
 	relayPrivateKey := nostr.GeneratePrivateKey()
 
-	state := relay29.Init(relay29.Options{
+	db := &slicestore.SliceStore{} // this only keeps things in memory, use a different eventstore in production
+	db.Init()
+
+	relay, _ := khatru29.Init(relay29.Options{
 		Domain:    "localhost:2929",
-		DB:        &slicestore.SliceStore{},
+		DB:        db,
 		SecretKey: relayPrivateKey,
 	})
 
 	// init relay
-	state.Relay.Info.Name = "very ephemeral chat relay"
-	state.Relay.Info.Description = "everything will be deleted as soon as I turn off my computer"
+	relay.Info.Name = "very ephemeral chat relay"
+	relay.Info.Description = "everything will be deleted as soon as I turn off my computer"
 
 	// extra policies
-	state.Relay.RejectEvent = slices.Insert(state.Relay.RejectEvent, 0,
+	relay.RejectEvent = append(relay.RejectEvent,
 		policies.PreventLargeTags(64),
 		policies.PreventTooManyIndexableTags(6, []int{9005}, nil),
 		policies.RestrictToSpecifiedKinds(
@@ -48,12 +51,12 @@ func main() {
 	)
 
 	// http routes
-	state.Relay.Router().HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	relay.Router().HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, "nothing to see here, you must use a nip-29 powered client")
 	})
 
 	fmt.Println("running on http://0.0.0.0:2929")
-	if err := http.ListenAndServe(":2929", state.Relay); err != nil {
+	if err := http.ListenAndServe(":2929", relay); err != nil {
 		log.Fatal("failed to serve")
 	}
 }
@@ -61,6 +64,15 @@ func main() {
 
 == How to use
 
-Basically you just call `relay29.Init()` and then you get back a `relay29.State` object that has a normal `khatru.Relay` inside and and also a map of `Group` objects that you can read but you should not modify manually. To modify these groups you must write moderation events with the `.AddEvent()` method of the `Relay`. This API may be improved later.
+Basically you just call `khatru29.Init()` and then you get back a `khatru.Relay` and a `relay29.State` instances. The state has inside it also a map of `Group` objects that you can read but you should not modify manually. To modify these groups you must write moderation events with the `.AddEvent()` method of the `Relay`. This API may be improved later.
 
 See link:examples/groups.fiatjaf.com/main.go[] for a (not very much) more complex example.
+
+== How it works
+
+What this library does is basically:
+- it keeps a list of of groups with metadata in memory (not the messages);
+- it checks a bunch of stuff for every event and filter received;
+- it acts on moderation events and on join-request events received and modify the group state;
+- it generates group metadata events (39000, 39001, 39002) events on the fly (these are not stored) and returns them to whoever queries them;
+- on startup it loads all the moderation events (9000, 9001, etc) from the database and rebuilds the group state from that (so if you want to modify the group state permanently you must publish one of these events to the relay — but of course you can also monkey-patch the map of groups in memory like an animal if you want);

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -8,8 +8,8 @@ import (
 	"github.com/fiatjaf/eventstore/slicestore"
 	"github.com/fiatjaf/khatru/policies"
 	"github.com/fiatjaf/relay29"
+	"github.com/fiatjaf/relay29/khatru29"
 	"github.com/nbd-wtf/go-nostr"
-	"golang.org/x/exp/slices"
 )
 
 func main() {
@@ -18,18 +18,18 @@ func main() {
 	db := &slicestore.SliceStore{}
 	db.Init()
 
-	state := relay29.Init(relay29.Options{
+	relay, _ := khatru29.Init(relay29.Options{
 		Domain:    "localhost:2929",
 		DB:        db,
 		SecretKey: relayPrivateKey,
 	})
 
 	// init relay
-	state.Relay.Info.Name = "very ephemeral chat relay"
-	state.Relay.Info.Description = "everything will be deleted as soon as I turn off my computer"
+	relay.Info.Name = "very ephemeral chat relay"
+	relay.Info.Description = "everything will be deleted as soon as I turn off my computer"
 
 	// extra policies
-	state.Relay.RejectEvent = slices.Insert(state.Relay.RejectEvent, 0,
+	relay.RejectEvent = append(relay.RejectEvent,
 		policies.PreventLargeTags(64),
 		policies.PreventTooManyIndexableTags(6, []int{9005}, nil),
 		policies.RestrictToSpecifiedKinds(
@@ -43,12 +43,12 @@ func main() {
 	)
 
 	// http routes
-	state.Relay.Router().HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	relay.Router().HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, "nothing to see here, you must use a nip-29 powered client")
 	})
 
 	fmt.Println("running on http://0.0.0.0:2929")
-	if err := http.ListenAndServe(":2929", state.Relay); err != nil {
+	if err := http.ListenAndServe(":2929", relay); err != nil {
 		log.Fatal("failed to serve")
 	}
 }

--- a/filter_policy.go
+++ b/filter_policy.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"slices"
 
-	"github.com/fiatjaf/khatru"
 	"github.com/nbd-wtf/go-nostr"
 	"github.com/nbd-wtf/go-nostr/nip29"
 )
 
-func (s *State) requireKindAndSingleGroupIDOrSpecificEventReference(ctx context.Context, filter nostr.Filter) (reject bool, msg string) {
+func (s *State) RequireKindAndSingleGroupIDOrSpecificEventReference(ctx context.Context, filter nostr.Filter) (reject bool, msg string) {
 	isMeta := false
 	isNormal := false
 	isReference := false
@@ -36,7 +35,7 @@ func (s *State) requireKindAndSingleGroupIDOrSpecificEventReference(ctx context.
 		}
 	}
 
-	authed := khatru.GetAuthed(ctx)
+	authed := s.GetAuthed(ctx)
 
 	switch {
 	case isNormal:

--- a/groups.go
+++ b/groups.go
@@ -1,0 +1,65 @@
+package relay29
+
+import (
+	"context"
+	"sync"
+
+	"github.com/nbd-wtf/go-nostr"
+	"github.com/nbd-wtf/go-nostr/nip29"
+	nip29_relay "github.com/nbd-wtf/go-nostr/nip29/relay"
+)
+
+type Group struct {
+	nip29.Group
+	mu sync.RWMutex
+}
+
+func (s *State) NewGroup(id string) *Group {
+	return &Group{
+		Group: nip29.Group{
+			Address: nip29.GroupAddress{
+				ID:    id,
+				Relay: "wss://" + s.Domain,
+			},
+			Members: map[string]*nip29.Role{},
+		},
+	}
+}
+
+// loadGroups loads all the group metadata from all the past action messages.
+func (s *State) loadGroups(ctx context.Context) {
+	groupMetadataEvents, _ := s.DB.QueryEvents(ctx, nostr.Filter{Kinds: []int{nostr.KindSimpleGroupCreateGroup}})
+	for evt := range groupMetadataEvents {
+		gtag := evt.Tags.GetFirst([]string{"h", ""})
+		id := (*gtag)[1]
+
+		group := s.NewGroup(id)
+		f := nostr.Filter{
+			Limit: 5000, Kinds: nip29.ModerationEventKinds, Tags: nostr.TagMap{"h": []string{id}},
+		}
+		ch, _ := s.DB.QueryEvents(ctx, f)
+
+		events := make([]*nostr.Event, 0, 5000)
+		for event := range ch {
+			events = append(events, event)
+		}
+		for i := len(events) - 1; i >= 0; i-- {
+			evt := events[i]
+			act, _ := nip29_relay.GetModerationAction(evt)
+			act.Apply(&group.Group)
+		}
+
+		s.Groups.Store(group.Address.ID, group)
+	}
+}
+
+func (s *State) GetGroupFromEvent(event *nostr.Event) *Group {
+	group, _ := s.Groups.Load(GetGroupIDFromEvent(event))
+	return group
+}
+
+func GetGroupIDFromEvent(event *nostr.Event) string {
+	gtag := event.Tags.GetFirst([]string{"h", ""})
+	groupId := (*gtag)[1]
+	return groupId
+}

--- a/khatru29/khatru29.go
+++ b/khatru29/khatru29.go
@@ -1,0 +1,52 @@
+package khatru29
+
+import (
+	"github.com/fiatjaf/khatru"
+	"github.com/fiatjaf/relay29"
+	"github.com/nbd-wtf/go-nostr"
+)
+
+func Init(opts relay29.Options) (*khatru.Relay, *relay29.State) {
+	pubkey, _ := nostr.GetPublicKey(opts.SecretKey)
+
+	// create a new relay29.State
+	state := relay29.New(opts)
+
+	// create a new khatru relay
+	relay := khatru.NewRelay()
+	relay.Info.PubKey = pubkey
+	relay.Info.SupportedNIPs = append(relay.Info.SupportedNIPs, 29)
+
+	// assign khatru relay to relay29.State
+	state.Relay = relay
+
+	// provide GetAuthed function
+	state.GetAuthed = khatru.GetAuthed
+
+	// apply basic relay policies
+	relay.StoreEvent = append(relay.StoreEvent, state.DB.SaveEvent)
+	relay.QueryEvents = append(relay.QueryEvents,
+		state.NormalEventQuery,
+		state.MetadataQueryHandler,
+		state.AdminsQueryHandler,
+		state.MembersQueryHandler,
+	)
+	relay.DeleteEvent = append(relay.DeleteEvent, state.DB.DeleteEvent)
+	relay.RejectFilter = append(relay.RejectFilter,
+		state.RequireKindAndSingleGroupIDOrSpecificEventReference,
+	)
+	relay.RejectEvent = append(relay.RejectEvent,
+		state.RequireHTagForExistingGroup,
+		state.RequireModerationEventsToBeRecent,
+		state.RestrictWritesBasedOnGroupRules,
+		state.RestrictInvalidModerationActions,
+		state.PreventWritingOfEventsJustDeleted,
+	)
+	relay.OnEventSaved = append(relay.OnEventSaved,
+		state.ApplyModerationAction,
+		state.ReactToJoinRequest,
+	)
+	relay.OnConnect = append(relay.OnConnect, khatru.RequestAuth)
+
+	return relay, state
+}

--- a/khatru29/relay_test.go
+++ b/khatru29/relay_test.go
@@ -1,4 +1,4 @@
-package relay29
+package khatru29
 
 import (
 	"context"
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/fiatjaf/eventstore/slicestore"
+	"github.com/fiatjaf/relay29"
 	"github.com/nbd-wtf/go-nostr"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/slices"
@@ -19,21 +20,21 @@ func startTestRelay() func() {
 	db := &slicestore.SliceStore{}
 	db.Init()
 
-	state := Init(Options{
+	relay, state := Init(relay29.Options{
 		Domain:    "localhost:29292",
 		DB:        db,
 		SecretKey: relayPrivateKey,
 	})
 
-	state.Relay.Info.Name = "very testy relay"
-	state.Relay.Info.Description = "this is just for testing"
+	relay.Info.Name = "very testy relay"
+	relay.Info.Description = "this is just for testing"
 
 	// don't do this at home -- we're going to remove one requirement to make tests simpler
-	state.Relay.RejectEvent = slices.DeleteFunc(state.Relay.RejectEvent, func(f func(ctx context.Context, event *nostr.Event) (reject bool, msg string)) bool {
-		return fmt.Sprintf("%v", []any{f}) == fmt.Sprintf("%v", []any{state.requireModerationEventsToBeRecent})
+	relay.RejectEvent = slices.DeleteFunc(relay.RejectEvent, func(f func(ctx context.Context, event *nostr.Event) (reject bool, msg string)) bool {
+		return fmt.Sprintf("%v", []any{f}) == fmt.Sprintf("%v", []any{state.RequireModerationEventsToBeRecent})
 	})
 
-	server := &http.Server{Addr: ":29292", Handler: state.Relay}
+	server := &http.Server{Addr: ":29292", Handler: relay}
 
 	go func() {
 		server.ListenAndServe()

--- a/state.go
+++ b/state.go
@@ -2,26 +2,26 @@ package relay29
 
 import (
 	"context"
-	"sync"
 
 	"github.com/fiatjaf/eventstore"
-	"github.com/fiatjaf/khatru"
 	"github.com/fiatjaf/set"
 	"github.com/nbd-wtf/go-nostr"
-	"github.com/nbd-wtf/go-nostr/nip29"
-	nip29_relay "github.com/nbd-wtf/go-nostr/nip29/relay"
 	"github.com/puzpuzpuz/xsync/v3"
 )
 
 type State struct {
-	Relay  *khatru.Relay
 	Domain string
 	Groups *xsync.MapOf[string, *Group]
 	DB     eventstore.Store
+	Relay  interface {
+		BroadcastEvent(*nostr.Event)
+		AddEvent(context.Context, *nostr.Event) (skipBroadcast bool, writeError error)
+	}
+	GetAuthed func(context.Context) string
 
 	deletedCache set.Set[string]
 	publicKey    string
-	privateKey   string
+	secretKey    string
 }
 
 type Options struct {
@@ -30,7 +30,7 @@ type Options struct {
 	SecretKey string
 }
 
-func Init(opts Options) *State {
+func New(opts Options) *State {
 	pubkey, _ := nostr.GetPublicKey(opts.SecretKey)
 
 	// events that just got deleted will be cached here for `tooOld` seconds such that someone doesn't rebroadcast
@@ -40,103 +40,18 @@ func Init(opts Options) *State {
 	// we keep basic data about all groups in memory
 	groups := xsync.NewMapOf[string, *Group]()
 
-	// we create a new khatru relay
-	relay := khatru.NewRelay()
-	relay.Info.PubKey = pubkey
-	relay.Info.SupportedNIPs = append(relay.Info.SupportedNIPs, 29)
-
 	state := &State{
-		relay,
-		opts.Domain,
-		groups,
-		opts.DB,
-		deletedCache,
-		pubkey,
-		opts.SecretKey,
+		Domain: opts.Domain,
+		Groups: groups,
+		DB:     opts.DB,
+
+		deletedCache: deletedCache,
+		publicKey:    pubkey,
+		secretKey:    opts.SecretKey,
 	}
 
 	// load all groups
 	state.loadGroups(context.Background())
 
-	// apply basic relay policies
-	relay.StoreEvent = append(relay.StoreEvent, state.DB.SaveEvent)
-	relay.QueryEvents = append(relay.QueryEvents,
-		state.normalEventQuery,
-		state.metadataQueryHandler,
-		state.adminsQueryHandler,
-		state.membersQueryHandler,
-	)
-	relay.DeleteEvent = append(relay.DeleteEvent, state.DB.DeleteEvent)
-	relay.RejectFilter = append(relay.RejectFilter,
-		state.requireKindAndSingleGroupIDOrSpecificEventReference,
-	)
-	relay.RejectEvent = append(relay.RejectEvent,
-		state.requireHTagForExistingGroup,
-		state.requireModerationEventsToBeRecent,
-		state.restrictWritesBasedOnGroupRules,
-		state.restrictInvalidModerationActions,
-		state.preventWritingOfEventsJustDeleted,
-	)
-	relay.OnEventSaved = append(relay.OnEventSaved,
-		state.applyModerationAction,
-		state.reactToJoinRequest,
-	)
-	relay.OnConnect = append(relay.OnConnect, khatru.RequestAuth)
-
 	return state
-}
-
-type Group struct {
-	nip29.Group
-	mu sync.RWMutex
-}
-
-func (s *State) NewGroup(id string) *Group {
-	return &Group{
-		Group: nip29.Group{
-			Address: nip29.GroupAddress{
-				ID:    id,
-				Relay: "wss://" + s.Domain,
-			},
-			Members: map[string]*nip29.Role{},
-		},
-	}
-}
-
-// loadGroups loads all the group metadata from all the past action messages.
-func (s *State) loadGroups(ctx context.Context) {
-	groupMetadataEvents, _ := s.DB.QueryEvents(ctx, nostr.Filter{Kinds: []int{nostr.KindSimpleGroupCreateGroup}})
-	for evt := range groupMetadataEvents {
-		gtag := evt.Tags.GetFirst([]string{"h", ""})
-		id := (*gtag)[1]
-
-		group := s.NewGroup(id)
-		f := nostr.Filter{
-			Limit: 5000, Kinds: nip29.ModerationEventKinds, Tags: nostr.TagMap{"h": []string{id}},
-		}
-		ch, _ := s.DB.QueryEvents(ctx, f)
-
-		events := make([]*nostr.Event, 0, 5000)
-		for event := range ch {
-			events = append(events, event)
-		}
-		for i := len(events) - 1; i >= 0; i-- {
-			evt := events[i]
-			act, _ := nip29_relay.GetModerationAction(evt)
-			act.Apply(&group.Group)
-		}
-
-		s.Groups.Store(group.Address.ID, group)
-	}
-}
-
-func (s *State) GetGroupFromEvent(event *nostr.Event) *Group {
-	group, _ := s.Groups.Load(GetGroupIDFromEvent(event))
-	return group
-}
-
-func GetGroupIDFromEvent(event *nostr.Event) string {
-	gtag := event.Tags.GetFirst([]string{"h", ""})
-	groupId := (*gtag)[1]
-	return groupId
 }


### PR DESCRIPTION
This allows this library to be used with https://github.com/fiatjaf/relayer and also with an strfry plugin (to be built).

See https://github.com/fiatjaf/relay29/pull/6