### PR TITLE
Reject filters implicitly rather that failing a whole request

### DIFF
--- a/filter_policy.go
+++ b/filter_policy.go
@@ -67,8 +67,8 @@ func (s *State) RequireKindAndSingleGroupIDOrSpecificEventReference(
 			}
 		}
 	case isReference:
-  	// don't reject wholesale, since a single req may have multiple filters
-  	// filters that we don't want to respond to are dropped in NormalEventQuery
+		// don't reject wholesale, since a single req may have multiple filters
+		// filters that we don't want to respond to are dropped in NormalEventQuery
 	case isMeta:
 		// should be fine
 	}

--- a/filter_policy.go
+++ b/filter_policy.go
@@ -67,20 +67,8 @@ func (s *State) RequireKindAndSingleGroupIDOrSpecificEventReference(
 			}
 		}
 	case isReference:
-		if refE, ok := filter.Tags["e"]; ok && len(refE) > 0 {
-			// "#e" tags specified -- pablo's magic discovery trick
-			// we'll handle this while fetching the events so that we don't reveal private content
-			return false, ""
-		} else if refA, ok := filter.Tags["a"]; ok && len(refA) > 0 {
-			// "#a" tags specified -- idem
-			return false, ""
-		} else if len(filter.IDs) > 0 {
-			// "ids" specified -- idem
-			return false, ""
-		} else {
-			// other tags are not supported (unless they come together with "h")
-			return true, "invalid query, must have 'h', 'e' or 'a' tag"
-		}
+  	// don't reject wholesale, since a single req may have multiple filters
+  	// filters that we don't want to respond to are dropped in NormalEventQuery
 	case isMeta:
 		// should be fine
 	}

--- a/queries.go
+++ b/queries.go
@@ -225,7 +225,8 @@ func (s *State) NormalEventQuery(ctx context.Context, filter nostr.Filter) (chan
 	ch := make(chan *nostr.Event)
 	authed := s.GetAuthed(ctx)
 	go func() {
-		// now here in refE/refA/ids we have to check for each result if it is allowed
+		// now here in refE/refA/ids we have to check for each result if it is allowed.
+		// otherwise, we refuse to respond to the request. TODO: raise a NOTICE for ignored filters
 		var results chan *nostr.Event
 		var err error
 		if refE, ok := filter.Tags["e"]; ok && len(refE) > 0 {


### PR DESCRIPTION
Flotilla (and NDK) batch requests, which results in valid filters being rejected along with invalid ones. An example:

```
["REQ","REQ-05681808",{"kinds":[11],"since":1734045039},{"kinds":[1111],"#K":["11"],"since":1734045039},{"kinds":[9],"#h":["5689390638509997"],"since":1734045039}]
```

This results in flaky loading of valid chat messages. It doesn't seem to follow that nip 29 support is incompatible with support of regular nostr events. Relay level authentication and policy is the correct tool for protecting a relay from spam, not feature support, which should be orthogonal (this isn't a commentary on whether nip 29 relays should accept other relays, but that should be up to the instance, not the implementation).

If a relay only accepts h-tagged events, returning no events for the first two filters is to be expected. Also, in the case that there are events with h tags that match the first two filters, it's reasonable to return only events that the user has access to based on the relay's prerogative to authorize users.

This PR might have many problems with it. I didn't fully understand the logic in NormalEventQuery, but I think my version is clearer (if maybe not quite as performant). 