### PR TITLE
Fix: incorrect negation in setting group.Closed

### DIFF
--- a/moderation_actions.go
+++ b/moderation_actions.go
@@ -194,7 +194,7 @@ func (a EditMetadata) Apply(group *nip29.Group) {
 		group.Private = *a.PrivateValue
 	}
 	if a.ClosedValue != nil {
-		group.Closed = !*a.ClosedValue
+		group.Closed = *a.ClosedValue
 	}
 }
 


### PR DESCRIPTION
Fixes a logic error where group.Closed was incorrectly assigned with negation.

Originally:
`group.Closed = !*a.ClosedValue
`
Now:
`group.Closed = *a.ClosedValue`