### PR TITLE
Fix panic when group is nil

### DIFF
--- a/event_policy.go
+++ b/event_policy.go
@@ -163,6 +163,9 @@ func (s *State) CheckPreviousTag(ctx context.Context, event *nostr.Event) (rejec
 
 func (s *State) AddToPreviousChecking(ctx context.Context, event *nostr.Event) {
 	group := s.GetGroupFromEvent(event)
+	if group == nil {
+		return
+	}
 	lastIndex := group.last50index.Add(1) - 1
 	group.last50[lastIndex%50] = event.ID
 }


### PR DESCRIPTION
Seems when sending a `kind 9008` delete group event, it first executes the group deletion, and then calls `AddToPreviousChecking`. As a result, the group cannot be found because it has already been deleted 